### PR TITLE
Add support for anonymous functions

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -302,9 +302,9 @@ export default class Parser {
   }
   protected functionDeclarationStatement(): FunctionDeclarationStmt {
     const functionKeyword = this.previous();
-    const anonymousFunction = this.peek().type === TokenType.LeftParen;
+    const isAnonymous = this.peek().type === TokenType.LeftParen;
     let nameToken;
-    if (!anonymousFunction) {
+    if (!isAnonymous) {
       nameToken = this.consume(
         TokenType.Identifier,
         "after 'function' keyword"
@@ -315,19 +315,19 @@ export default class Parser {
     const args = this.args();
     const secondParen = this.previous();
     let equals;
-    if (!anonymousFunction) {
+    if (!isAnonymous) {
       this.consume(TokenType.Equal, "after function parameters");
       equals = this.previous();
     }
     const body = this.expression();
     let semicolon;
-    if (!anonymousFunction) {
+    if (!isAnonymous) {
       this.consume(TokenType.Semicolon, "after function declaration");
       semicolon = this.previous();
     }
     return new FunctionDeclarationStmt(
       this.getLocation(),
-      anonymousFunction ? "" : (nameToken as LiteralToken<string>).value,
+      isAnonymous ? "" : (nameToken as LiteralToken<string>).value,
       args,
       body,
       {


### PR DESCRIPTION
Anonymous functions is a very rarely used feature, but [it's used in NopSCADlib](https://github.com/nophead/NopSCADlib/blob/28d8cba98c64ab97704a1bd5be35529d406389e4/utils/maths.scad#L160).

I tried to add support for them in the least intrusive way. 

A separate class would probably match the coding style a bit better, but that'd need adding the `visitNewClass` methods to the visitor API, updating all existing implementations, and would also break people relying on the existing visitor API.

Let me know if this is good enough to merge