### PR TITLE
Support identifiers starting with a digit

### DIFF
--- a/src/Lexer.test.ts
+++ b/src/Lexer.test.ts
@@ -105,7 +105,6 @@ describe("Lexer", () => {
   });
   it("scans identifiers starting with a digit", () => {
     const expectNumberSemi = (str: string) => {
-      // console.log("for ", str);
       expect(lexToTTStream(str)).toEqual([
         TokenType.NumberLiteral,
         TokenType.Semicolon,

--- a/src/Lexer.test.ts
+++ b/src/Lexer.test.ts
@@ -103,6 +103,53 @@ describe("Lexer", () => {
       TokenType.Eot,
     ]);
   });
+  it("scans identifiers starting with a digit", () => {
+    const expectNumberSemi = (str: string) => {
+      // console.log("for ", str);
+      expect(lexToTTStream(str)).toEqual([
+        TokenType.NumberLiteral,
+        TokenType.Semicolon,
+        TokenType.Eot,
+      ]);
+    };
+
+    expectNumberSemi("1e3;");
+    expectNumberSemi(".3e3;");
+
+    const expectIdentifierSemi = (str: string) =>
+      expect(lexToTTStream(str)).toEqual([
+        TokenType.Identifier,
+        TokenType.Semicolon,
+        TokenType.Eot,
+      ]);
+
+    expectIdentifierSemi("0z;");
+    expectIdentifierSemi("0ea;");
+
+    expectIdentifierSemi("999e9e9999;");
+    expect(lexToTTStream("999e9e9999")).toEqual([
+      TokenType.NumberLiteral,
+      TokenType.Eot,
+    ]);
+
+    expect(lexToTTStream("7_")).toEqual([TokenType.Identifier, TokenType.Eot]);
+    expect(lexToTTStream("7_1")).toEqual([TokenType.Identifier, TokenType.Eot]);
+    expect(lexToTTStream("0a1")).toEqual([TokenType.Identifier, TokenType.Eot]);
+
+    expect(lexToTTStream("0e.x")).toEqual([
+      TokenType.Identifier,
+      TokenType.Dot,
+      TokenType.Identifier,
+      TokenType.Eot,
+    ]);
+
+    expect(lexToTTStream("7_segDisplay.x")).toEqual([
+      TokenType.Identifier,
+      TokenType.Dot,
+      TokenType.Identifier,
+      TokenType.Eot,
+    ]);
+  });
   it("scans string literals", () => {
     const tts = lexToTTStream(`"abc";`);
     expect(tts).toEqual([
@@ -217,7 +264,6 @@ describe("Lexer", () => {
     it("throws LexingError when an invalid number is given", () => {
       expect(() => testNumberLexing("2.2.2")).toThrowError(LexingError);
       expect(() => testNumberLexing("999e99999")).toThrowError(LexingError);
-      expect(() => testNumberLexing("999e9e9999")).toThrowError(LexingError);
     });
     it("lexes numbers starting with a dot", () => {
       expect(testNumberLexing(".9")).toEqual(0.9);

--- a/src/Lexer.test.ts
+++ b/src/Lexer.test.ts
@@ -127,7 +127,7 @@ describe("Lexer", () => {
 
     expectIdentifierSemi("999e9e9999;");
     expect(lexToTTStream("999e9e9999")).toEqual([
-      TokenType.NumberLiteral,
+      TokenType.Identifier,
       TokenType.Eot,
     ]);
 

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -201,7 +201,7 @@ export default class Lexer {
         break;
       default:
         if (/[0-9]/.test(c)) {
-          this.consumeNumberLiteral();
+          this.consumeNumberOrIdentifierOrKeyword();
         } else if (/[A-Za-z\$_]/.test(c)) {
           this.consumeIdentifierOrKeyword();
         } else {
@@ -294,6 +294,36 @@ export default class Lexer {
       return;
     }
     this.addToken(TokenType.Identifier, lexeme);
+  }
+
+  protected consumeNumberOrIdentifierOrKeyword() {
+    // OpenSCAD does accept identifiers starting with a digit.
+    // `9e9e9=1;echo(9e9e9);` is a valid code, `9e9=1;` produces a syntax error.
+    // Docs don't specify how conflicts are resolved, but from experiments
+    // it seems like a number is chosen unless an identifier is a longer match.
+    // That would be consistent with how lex/flex generated lexers work.
+
+    let maxWordLength = 1;
+    while (
+      this.start.char + maxWordLength < this.codeFile.code.length &&
+      /[0-9a-zA-Z_\$]/.test(this.codeFile.code[this.start.char + maxWordLength])
+    ) {
+      maxWordLength++;
+    }
+
+    const possibleNumberStarts = [
+      this.peekRegex(/[0-9]+/),
+      this.peekRegex(/[0-9]+[.]/),
+      this.peekRegex(/[0-9]+[eE][+-]?[0-9]+/),
+    ];
+    const numberLength = Math.max(...possibleNumberStarts.map((x) => x.length));
+
+    // If number is longer or same length as an indentifier - number wins.
+    if (numberLength >= maxWordLength) {
+      return this.consumeNumberLiteral();
+    } else {
+      return this.consumeIdentifierOrKeyword();
+    }
   }
 
   protected consumeFileNameInChevrons() {
@@ -407,5 +437,11 @@ export default class Lexer {
   protected peekNext() {
     if (this.charOffset + 1 >= this.codeFile.code.length) return "\0";
     return this.codeFile.code[this.charOffset + 1];
+  }
+
+  protected peekRegex(regex: RegExp) {
+    const text = this.codeFile.code.slice(this.start.char);
+    const match = regex.exec(text);
+    return !match || match.index !== 0 ? "" : match[0];
   }
 }

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -303,12 +303,12 @@ export default class Lexer {
     // it seems like a number is chosen unless an identifier is a longer match.
     // That would be consistent with how lex/flex generated lexers work.
 
-    let maxWordLength = 1;
+    let wordLength = 1;
     while (
-      this.start.char + maxWordLength < this.codeFile.code.length &&
-      /[0-9a-zA-Z_\$]/.test(this.codeFile.code[this.start.char + maxWordLength])
+      this.start.char + wordLength < this.codeFile.code.length &&
+      /[0-9a-zA-Z_\$]/.test(this.codeFile.code[this.start.char + wordLength])
     ) {
-      maxWordLength++;
+      wordLength++;
     }
 
     const possibleNumberStarts = [
@@ -319,7 +319,7 @@ export default class Lexer {
     const numberLength = Math.max(...possibleNumberStarts.map((x) => x.length));
 
     // If number is longer or same length as an indentifier - number wins.
-    if (numberLength >= maxWordLength) {
+    if (numberLength >= wordLength) {
       return this.consumeNumberLiteral();
     } else {
       return this.consumeIdentifierOrKeyword();


### PR DESCRIPTION
Below is valid code in OpenSCAD:
```
7_segments = [];
1e1e1 = 2;
```
But at the moment `openscad-parser` rejects it.
While it's a weird feature for a "programming" language, it is being [used in NopSCADlib](https://github.com/nophead/NopSCADlib/blob/28d8cba98c64ab97704a1bd5be35529d406389e4/vitamins/7_segment.scad).
