### PR TITLE
Support hexadecimal integer literals (0x...)

### DIFF
--- a/src/Lexer.test.ts
+++ b/src/Lexer.test.ts
@@ -322,10 +322,6 @@ describe("Lexer", () => {
       ]);
     });
 
-    // Ground truth verified directly against a local openscad install:
-    // hex literals use a lowercase "0x" prefix only - "0X..." falls through
-    // to being lexed as a plain (deprecated, leading-digit) identifier, same
-    // as an out-of-range digit like "0x1g" or a bare "0x" with no digits.
     it("lexes hexadecimal integer literals", () => {
       expect(testNumberLexing("0x0")).toEqual(0);
       expect(testNumberLexing("0xff")).toEqual(255);

--- a/src/Lexer.test.ts
+++ b/src/Lexer.test.ts
@@ -321,6 +321,53 @@ describe("Lexer", () => {
         TokenType.Eot,
       ]);
     });
+
+    // Ground truth verified directly against a local openscad install:
+    // hex literals use a lowercase "0x" prefix only - "0X..." falls through
+    // to being lexed as a plain (deprecated, leading-digit) identifier, same
+    // as an out-of-range digit like "0x1g" or a bare "0x" with no digits.
+    it("lexes hexadecimal integer literals", () => {
+      expect(testNumberLexing("0x0")).toEqual(0);
+      expect(testNumberLexing("0xff")).toEqual(255);
+      expect(testNumberLexing("0xFF")).toEqual(255);
+      expect(testNumberLexing("0x1A")).toEqual(26);
+      expect(testNumberLexing("0x1F600")).toEqual(0x1f600);
+      expect(testNumberLexing("0x00000001")).toEqual(1);
+    });
+    it("only accepts a lowercase 0x prefix - 0X falls back to an identifier", () => {
+      expect(lexToTTStream("0X1A;")).toEqual([
+        TokenType.Identifier,
+        TokenType.Semicolon,
+        TokenType.Eot,
+      ]);
+    });
+    it("a hex prefix with no valid hex digit after it falls back to an identifier", () => {
+      expect(lexToTTStream("0x;")).toEqual([
+        TokenType.Identifier,
+        TokenType.Semicolon,
+        TokenType.Eot,
+      ]);
+      expect(lexToTTStream("0x1g;")).toEqual([
+        TokenType.Identifier,
+        TokenType.Semicolon,
+        TokenType.Eot,
+      ]);
+    });
+    it("stops at the first non-hex-digit character, same as the identifier-vs-number race for decimals", () => {
+      expect(lexToTTStream("0x1Axyz;")).toEqual([
+        TokenType.Identifier,
+        TokenType.Semicolon,
+        TokenType.Eot,
+      ]);
+    });
+    it("a trailing dot after a hex literal is not a hex float - it starts a new number", () => {
+      expect(lexToTTStream("0x1A.5;")).toEqual([
+        TokenType.NumberLiteral,
+        TokenType.NumberLiteral,
+        TokenType.Semicolon,
+        TokenType.Eot,
+      ]);
+    });
   });
 
   describe("string lexing", () => {

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -295,6 +295,18 @@ export default class Lexer {
     }
     this.addToken(TokenType.NumberLiteral, value);
   }
+  protected consumeHexNumberLiteral() {
+    this.advance(); // 0
+    this.advance(); // x
+    while (/[0-9a-fA-F]/.test(this.peek())) {
+      this.advance();
+    }
+    const lexeme = this.codeFile.code.substring(
+      this.start.char,
+      this.charOffset
+    );
+    this.addToken(TokenType.NumberLiteral, parseInt(lexeme.slice(2), 16));
+  }
   protected consumeIdentifierOrKeyword() {
     while (/[A-Za-z0-9_\$]/.test(this.peek()) && !this.isAtEnd()) {
       this.advance();
@@ -328,6 +340,17 @@ export default class Lexer {
       /[0-9a-zA-Z_\$]/.test(this.codeFile.code[this.start.char + wordLength])
     ) {
       wordLength++;
+    }
+
+    // Real openscad only recognizes a lowercase "0x" prefix - "0X1A", "0x1g"
+    // (an invalid hex digit) and "0x" (no digits) all fall through to being
+    // lexed as an identifier instead, with the usual leading-digit
+    // deprecation warning. Checked first since a match here is always at
+    // least as long as `possibleNumberStarts` below can get on the same
+    // input (that regex only sees the leading "0").
+    const hexMatch = this.peekRegex(/^0x[0-9a-fA-F]+/);
+    if (hexMatch.length >= wordLength) {
+      return this.consumeHexNumberLiteral();
     }
 
     const possibleNumberStarts = [

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -342,12 +342,8 @@ export default class Lexer {
       wordLength++;
     }
 
-    // Real openscad only recognizes a lowercase "0x" prefix - "0X1A", "0x1g"
-    // (an invalid hex digit) and "0x" (no digits) all fall through to being
-    // lexed as an identifier instead, with the usual leading-digit
-    // deprecation warning. Checked first since a match here is always at
-    // least as long as `possibleNumberStarts` below can get on the same
-    // input (that regex only sees the leading "0").
+    // Only lowercase "0x" is a hex prefix - "0X1A", "0x1g", "0x" fall
+    // through to being lexed as an identifier.
     const hexMatch = this.peekRegex(/^0x[0-9a-fA-F]+/);
     if (hexMatch.length >= wordLength) {
       return this.consumeHexNumberLiteral();


### PR DESCRIPTION
Real OpenSCAD accepts a lowercase `0x` prefix followed by one or more hex digits as an integer literal. This lexer had zero support for it — `a = 0x1F600;` silently lexed as an unassigned identifier reference (`undef`, no error) instead of the number `128512`.

Verified against a local OpenSCAD install: only a lowercase `0x` prefix is recognized — `0X1A`, `0x1g` (invalid hex digit), and `0x` (no digits) all fall back to being lexed as a plain identifier, same as the existing leading-digit deprecation path.

Adds `consumeHexNumberLiteral()` and a check in the existing number-vs-identifier length race in `consumeNumberOrIdentifierOrKeyword()`, plus 5 new `Lexer.test.ts` cases covering the value-correctness and fallback-to-identifier edge cases above.