### PR TITLE
Support bitwise/shift operators (& | ~ << >>)

### DIFF
--- a/src/Lexer.test.ts
+++ b/src/Lexer.test.ts
@@ -208,13 +208,8 @@ describe("Lexer", () => {
   it("throws LexingError on unterminated multiline comments", () => {
     expect(() => lexToTTStream(`/* ahdsh`)).toThrowError(LexingError);
   });
-  it("throws LexingError on single & and single |", () => {
-    expect(() => lexToTTStream(`&`)).toThrowError(LexingError);
-    expect(() => lexToTTStream(`|`)).toThrowError(LexingError);
-  });
-
   it("throws LexingError on unexpected characters", () => {
-    expect(() => lexToTTStream(`~~~~~~`)).toThrowError(LexingError);
+    expect(() => lexToTTStream(`@@@@@@`)).toThrowError(LexingError);
   });
 
   it("adds extraTokens when scanning comments", () => {
@@ -318,6 +313,94 @@ describe("Lexer", () => {
 
       expect(lexToTTStream(`1.27e-4`)).toEqual([
         TokenType.NumberLiteral,
+        TokenType.Eot,
+      ]);
+    });
+  });
+
+  describe("bitwise and shift operator lexing", () => {
+    it("lexes single & and | as their own tokens", () => {
+      expect(lexToTTStream(`a & b | c;`)).toEqual([
+        TokenType.Identifier,
+        TokenType.Ampersand,
+        TokenType.Identifier,
+        TokenType.Pipe,
+        TokenType.Identifier,
+        TokenType.Semicolon,
+        TokenType.Eot,
+      ]);
+    });
+    it("still lexes && and || as AND/OR, not two Ampersand/Pipe tokens", () => {
+      expect(lexToTTStream(`a && b || c;`)).toEqual([
+        TokenType.Identifier,
+        TokenType.AND,
+        TokenType.Identifier,
+        TokenType.OR,
+        TokenType.Identifier,
+        TokenType.Semicolon,
+        TokenType.Eot,
+      ]);
+    });
+    it("lexes ~ as its own token", () => {
+      expect(lexToTTStream(`~a;`)).toEqual([
+        TokenType.Tilde,
+        TokenType.Identifier,
+        TokenType.Semicolon,
+        TokenType.Eot,
+      ]);
+    });
+    it("lexes << and >> as their own tokens, distinct from repeated < or >", () => {
+      expect(lexToTTStream(`a << b >> c;`)).toEqual([
+        TokenType.Identifier,
+        TokenType.ShiftLeft,
+        TokenType.Identifier,
+        TokenType.ShiftRight,
+        TokenType.Identifier,
+        TokenType.Semicolon,
+        TokenType.Eot,
+      ]);
+    });
+    it("disambiguates <</>> from <=/>= and </>", () => {
+      expect(lexToTTStream(`a<b;`)).toEqual([
+        TokenType.Identifier,
+        TokenType.Less,
+        TokenType.Identifier,
+        TokenType.Semicolon,
+        TokenType.Eot,
+      ]);
+      expect(lexToTTStream(`a<=b;`)).toEqual([
+        TokenType.Identifier,
+        TokenType.LessEqual,
+        TokenType.Identifier,
+        TokenType.Semicolon,
+        TokenType.Eot,
+      ]);
+      expect(lexToTTStream(`a<<b;`)).toEqual([
+        TokenType.Identifier,
+        TokenType.ShiftLeft,
+        TokenType.Identifier,
+        TokenType.Semicolon,
+        TokenType.Eot,
+      ]);
+      expect(lexToTTStream(`a>b;`)).toEqual([
+        TokenType.Identifier,
+        TokenType.Greater,
+        TokenType.Identifier,
+        TokenType.Semicolon,
+        TokenType.Eot,
+      ]);
+      expect(lexToTTStream(`a>=b;`)).toEqual([
+        TokenType.Identifier,
+        TokenType.GreaterEqual,
+        TokenType.Identifier,
+        TokenType.Semicolon,
+        TokenType.Eot,
+      ]);
+      expect(lexToTTStream(`a>>b;`)).toEqual([
+        TokenType.Identifier,
+        TokenType.ShiftRight,
+        TokenType.Identifier,
+        TokenType.Semicolon,
         TokenType.Eot,
       ]);
     });

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -5,7 +5,6 @@ import ErrorCollector from "./ErrorCollector";
 import {
   IllegalStringEscapeSequenceLexingError,
   InvalidNumberLiteralLexingError,
-  SingleCharacterNotAllowedLexingError,
   TooManyDotsInNumberLiteralLexingError,
   TooManyEInNumberLiteralLexingError,
   UnexpectedCharacterLexingError,
@@ -160,14 +159,18 @@ export default class Lexer {
         }
         break;
       case "<":
-        if (this.match("=")) {
+        if (this.match("<")) {
+          this.addToken(TokenType.ShiftLeft);
+        } else if (this.match("=")) {
           this.addToken(TokenType.LessEqual);
         } else {
           this.addToken(TokenType.Less);
         }
         break;
       case ">":
-        if (this.match("=")) {
+        if (this.match(">")) {
+          this.addToken(TokenType.ShiftRight);
+        } else if (this.match("=")) {
           this.addToken(TokenType.GreaterEqual);
         } else {
           this.addToken(TokenType.Greater);
@@ -184,19 +187,18 @@ export default class Lexer {
         if (this.match("&")) {
           this.addToken(TokenType.AND);
         } else {
-          throw this.errorCollector.reportError(
-            new SingleCharacterNotAllowedLexingError(this.getLoc(), "&")
-          );
+          this.addToken(TokenType.Ampersand);
         }
         break;
       case "|":
         if (this.match("|")) {
           this.addToken(TokenType.OR);
         } else {
-          throw this.errorCollector.reportError(
-            new SingleCharacterNotAllowedLexingError(this.getLoc(), "&")
-          );
+          this.addToken(TokenType.Pipe);
         }
+        break;
+      case "~":
+        this.addToken(TokenType.Tilde);
         break;
       case "\n":
         this.currentExtraTokens.push(new NewLineExtraToken(this.getLoc()));

--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -524,6 +524,193 @@ describe("Parser", () => {
     expect(unary.operation).toEqual(TokenType.Plus);
     expect(unary).toHaveProperty("right.value", 32);
   });
+  it("parses the '~' unary operator", () => {
+    const file = doParse(`
+      x = ~5;
+    `);
+    expect(file.statements[0]).toBeInstanceOf(AssignmentNode);
+    const a = file.statements[0] as AssignmentNode;
+    expect(a.value).toBeInstanceOf(UnaryOpExpr);
+    const unary = a.value as UnaryOpExpr;
+    expect(unary.operation).toEqual(TokenType.Tilde);
+    expect(unary).toHaveProperty("right.value", 5);
+  });
+  it("parses the '&' and '|' binary operators", () => {
+    const file = doParse(`
+      x = 5 & 3;
+      y = 5 | 2;
+    `);
+    expect(file.statements[0]).toBeInstanceOf(AssignmentNode);
+    expect(file.statements).toHaveProperty(
+      [0, "value", "operation"],
+      TokenType.Ampersand
+    );
+    expect(file.statements).toHaveProperty([0, "value", "left", "value"], 5);
+    expect(file.statements).toHaveProperty([0, "value", "right", "value"], 3);
+    expect(file.statements).toHaveProperty(
+      [1, "value", "operation"],
+      TokenType.Pipe
+    );
+  });
+  it("parses the '<<' and '>>' shift operators", () => {
+    const file = doParse(`
+      x = 1 << 4;
+      y = 256 >> 4;
+    `);
+    expect(file.statements).toHaveProperty(
+      [0, "value", "operation"],
+      TokenType.ShiftLeft
+    );
+    expect(file.statements).toHaveProperty([0, "value", "left", "value"], 1);
+    expect(file.statements).toHaveProperty([0, "value", "right", "value"], 4);
+    expect(file.statements).toHaveProperty(
+      [1, "value", "operation"],
+      TokenType.ShiftRight
+    );
+  });
+  it("'<<' and '>>' are left-associative", () => {
+    const file = doParse(`
+      x = 1 << 2 << 3;
+    `);
+    const a = file.statements[0] as AssignmentNode;
+    expect(a.value).toHaveProperty("operation", TokenType.ShiftLeft);
+    expect(a.value).toHaveProperty("left.operation", TokenType.ShiftLeft);
+    expect(a.value).toHaveProperty("left.left.value", 1);
+    expect(a.value).toHaveProperty("left.right.value", 2);
+    expect(a.value).toHaveProperty("right.value", 3);
+  });
+  it("parses '&', '|', '<<', '>>' with the correct relative precedence", () => {
+    // Grammar (tightest to loosest of this family): shift (<< >>) > binaryand
+    // (&) > binaryor (|). Each case picks operators where the wrong
+    // precedence would nest the tree differently.
+    const file = doParse(`
+      a = 1 | 2 & 6;
+      b = 4 << 1 & 3;
+      c = 1 | 2 << 1;
+    `);
+    expect(file.statements).toHaveProperty(
+      [0, "value", "operation"],
+      TokenType.Pipe
+    );
+    expect(file.statements).toHaveProperty([0, "value", "left", "value"], 1);
+    expect(file.statements).toHaveProperty(
+      [0, "value", "right", "operation"],
+      TokenType.Ampersand
+    );
+
+    expect(file.statements).toHaveProperty(
+      [1, "value", "operation"],
+      TokenType.Ampersand
+    );
+    expect(file.statements).toHaveProperty(
+      [1, "value", "left", "operation"],
+      TokenType.ShiftLeft
+    );
+    expect(file.statements).toHaveProperty([1, "value", "right", "value"], 3);
+
+    expect(file.statements).toHaveProperty(
+      [2, "value", "operation"],
+      TokenType.Pipe
+    );
+    expect(file.statements).toHaveProperty(
+      [2, "value", "right", "operation"],
+      TokenType.ShiftLeft
+    );
+  });
+  it("'+'/'-' bind tighter than '<<'/'>>', which binds tighter than '&', which binds tighter than '|' and comparison", () => {
+    const file = doParse(`
+      a = 4 << 1 + 1;
+      b = 1 & 1 == 1;
+    `);
+    expect(file.statements).toHaveProperty(
+      [0, "value", "operation"],
+      TokenType.ShiftLeft
+    );
+    expect(file.statements).toHaveProperty(
+      [0, "value", "right", "operation"],
+      TokenType.Plus
+    );
+
+    expect(file.statements).toHaveProperty(
+      [1, "value", "operation"],
+      TokenType.EqualEqual
+    );
+    expect(file.statements).toHaveProperty(
+      [1, "value", "left", "operation"],
+      TokenType.Ampersand
+    );
+  });
+  it("unary '~' binds tighter than '<<', '&', and '|'", () => {
+    const file = doParse(`
+      a = ~1 + 1;
+    `);
+    expect(file.statements).toHaveProperty(
+      [0, "value", "operation"],
+      TokenType.Plus
+    );
+    expect(file.statements).toHaveProperty(
+      [0, "value", "left", "operation"],
+      TokenType.Tilde
+    );
+  });
+  it("unary '~' composes correctly as either operand of '<<', '&', and '|'", () => {
+    const file = doParse(`
+      a = ~4 << 1;
+      b = 1 << ~4;
+      c = ~4 & 1;
+      d = 1 & ~4;
+      e = ~4 | 1;
+      f = 1 | ~4;
+    `);
+    expect(file.statements).toHaveProperty(
+      [0, "value", "operation"],
+      TokenType.ShiftLeft
+    );
+    expect(file.statements).toHaveProperty(
+      [0, "value", "left", "operation"],
+      TokenType.Tilde
+    );
+    expect(file.statements).toHaveProperty(
+      [1, "value", "operation"],
+      TokenType.ShiftLeft
+    );
+    expect(file.statements).toHaveProperty(
+      [1, "value", "right", "operation"],
+      TokenType.Tilde
+    );
+    expect(file.statements).toHaveProperty(
+      [2, "value", "operation"],
+      TokenType.Ampersand
+    );
+    expect(file.statements).toHaveProperty(
+      [2, "value", "left", "operation"],
+      TokenType.Tilde
+    );
+    expect(file.statements).toHaveProperty(
+      [3, "value", "operation"],
+      TokenType.Ampersand
+    );
+    expect(file.statements).toHaveProperty(
+      [3, "value", "right", "operation"],
+      TokenType.Tilde
+    );
+    expect(file.statements).toHaveProperty(
+      [4, "value", "operation"],
+      TokenType.Pipe
+    );
+    expect(file.statements).toHaveProperty(
+      [4, "value", "left", "operation"],
+      TokenType.Tilde
+    );
+    expect(file.statements).toHaveProperty(
+      [5, "value", "operation"],
+      TokenType.Pipe
+    );
+    expect(file.statements).toHaveProperty(
+      [5, "value", "right", "operation"],
+      TokenType.Tilde
+    );
+  });
   it("parses comparsion operators", () => {
     const file = doParse(`
       if(x > 2) {

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -718,7 +718,7 @@ export default class Parser {
     return expr;
   }
   protected comparsion(): Expression {
-    let expr = this.addition();
+    let expr = this.binaryOr();
     while (
       this.matchToken(
         TokenType.Less,
@@ -727,6 +727,48 @@ export default class Parser {
         TokenType.GreaterEqual
       )
     ) {
+      const operator = this.previous();
+      const right = this.binaryOr();
+      expr = new BinaryOpExpr(expr, operator.type, right, {
+        operator,
+      });
+    }
+    return expr;
+  }
+  /**
+   * Parses the '|' operator.
+   */
+  protected binaryOr(): Expression {
+    let expr = this.binaryAnd();
+    while (this.matchToken(TokenType.Pipe)) {
+      const operator = this.previous();
+      const right = this.binaryAnd();
+      expr = new BinaryOpExpr(expr, operator.type, right, {
+        operator,
+      });
+    }
+    return expr;
+  }
+  /**
+   * Parses the '&' operator.
+   */
+  protected binaryAnd(): Expression {
+    let expr = this.shift();
+    while (this.matchToken(TokenType.Ampersand)) {
+      const operator = this.previous();
+      const right = this.shift();
+      expr = new BinaryOpExpr(expr, operator.type, right, {
+        operator,
+      });
+    }
+    return expr;
+  }
+  /**
+   * Parses the '<<' and '>>' operators.
+   */
+  protected shift(): Expression {
+    let expr = this.addition();
+    while (this.matchToken(TokenType.ShiftLeft, TokenType.ShiftRight)) {
       const operator = this.previous();
       const right = this.addition();
       expr = new BinaryOpExpr(expr, operator.type, right, {
@@ -779,7 +821,14 @@ export default class Parser {
    * Parses +expr, -expr and !expr.
    */
   protected unary(): Expression {
-    if (this.matchToken(TokenType.Plus, TokenType.Minus, TokenType.Bang)) {
+    if (
+      this.matchToken(
+        TokenType.Plus,
+        TokenType.Minus,
+        TokenType.Bang,
+        TokenType.Tilde
+      )
+    ) {
       const operator = this.previous();
       const right = this.unary();
       return new UnaryOpExpr(operator.type, right, {

--- a/src/TokenType.ts
+++ b/src/TokenType.ts
@@ -117,7 +117,7 @@ enum TokenType {
   Slash,
   Percent,
   Caret,
-  
+
   /**
    * Left parenthesis: (
    */
@@ -179,6 +179,27 @@ enum TokenType {
    * The include keyword.
    */
   Include,
+
+  /**
+   * &
+   */
+  Ampersand,
+  /**
+   * |
+   */
+  Pipe,
+  /**
+   * ~
+   */
+  Tilde,
+  /**
+   * <<
+   */
+  ShiftLeft,
+  /**
+   * >>
+   */
+  ShiftRight,
 }
 
 export default TokenType;

--- a/src/friendlyTokenNames.ts
+++ b/src/friendlyTokenNames.ts
@@ -49,4 +49,9 @@ export default {
   [TokenType.Use]: "'use' (Use)",
   [TokenType.FilenameInChevrons]: "filename (FilenameInChevrons)",
   [TokenType.Include]: "'include' (Include)",
+  [TokenType.Ampersand]: "'&' (Ampersand)",
+  [TokenType.Pipe]: "'|' (Pipe)",
+  [TokenType.Tilde]: "'~' (Tilde)",
+  [TokenType.ShiftLeft]: "'<<' (ShiftLeft)",
+  [TokenType.ShiftRight]: "'>>' (ShiftRight)",
 };


### PR DESCRIPTION
Real openscad's grammar (`parser.y`) has a `binaryor`/`binaryand`/`shift` tier between `comparison` and `addition`: `|` loosest, `&` tighter, `<<`/`>>` tighter still but looser than `+`/`-`. Unary `~` sits at the same tier as unary `!`/`-`. None of these were lexed at all — `&`/`|` threw on their own, `~` was an unrecognized character, and `<<`/`>>` lexed as two separate `<`/`>` tokens each.

Adds `Ampersand`/`Pipe`/`Tilde`/`ShiftLeft`/`ShiftRight` token types (appended at the end of the enum to avoid renumbering existing snapshot-tested tokens), wires `<<`/`>>` disambiguation ahead of `<=`/`>=` in the lexer, and splices `binaryOr`/`binaryAnd`/`shift` into the parser's precedence chain plus `~` into `unary()`.

Verified token disambiguation and precedence against openscad's own `lexer.l`/`parser.y` grammar rules directly (a local checkout of the openscad source), not just black-box guessing. Tests cover tokenization, operator precedence (including against the pre-existing arithmetic/comparison tiers), left-associativity of `<<`/`>>`, and unary `~` composing correctly on either side of `<<`/`&`/`|`.