### PR TITLE
Require comma between call arguments

### DIFF
--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -375,6 +375,27 @@ describe("Parser", () => {
     `)
     ).toThrow(ParsingError);
   });
+  it("throws on a missing comma between positional call arguments", () => {
+    expect(() =>
+      doParse(`
+        echo(1 2);
+      `)
+    ).toThrow(ParsingError);
+  });
+  it("throws on a missing comma between named call arguments", () => {
+    expect(() =>
+      doParse(`
+        echo(a = 1 b = 2);
+      `)
+    ).toThrow(ParsingError);
+  });
+  it("throws on a missing comma between mixed call arguments", () => {
+    expect(() =>
+      doParse(`
+        echo(1 a = 2);
+      `)
+    ).toThrow(ParsingError);
+  });
   it("parses member lookup expressions", () => {
     const file = doParse(`
       x = abc.y;

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -528,6 +528,8 @@ export default class Parser {
       if (this.matchToken(TokenType.RightParen)) {
         return args;
       }
+      // neither a comma nor the closing paren followed the argument
+      break;
     }
     if (this.isAtEnd()) {
       throw this.errorCollector.reportError(


### PR DESCRIPTION
## Summary

`echo(1 2)` (and similarly `foo(a=1 b=2)`) currently parses without error — the argument-list parser treats the missing comma as if it weren't required, silently accepting `1` and `2` as two separate positional arguments. Real OpenSCAD raises a syntax error here.

## Root cause

In `args()` (`src/Parser.ts`), after parsing an argument, the loop only special-cased the "comma found" and "right paren found" branches. When neither matched, execution fell through to the bottom of `while(true)` and looped back around to parse another argument, instead of hitting the existing "unexpected token in argument list" error path.

## Fix

Added a `break` so that when an argument is followed by neither `,` nor `)`, the loop exits into the pre-existing error-reporting code (the same `UnexpectedTokenInNamedArgumentsListParsingError` already used for other malformed argument lists, e.g. `module garbage (==!>XDD) {}`).

## Test plan
- [x] Added failing tests first (TDD) for missing comma between positional, named, and mixed call arguments; confirmed they failed against the old code
- [x] Applied the fix; all 3 new tests pass
- [x] Full suite passes: 219 passed, 2 skipped, no regressions (including existing mixed-argument and keyword-module snapshot tests that share this code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)