### PR TITLE
Fix '^' vs unary operator precedence to match real OpenSCAD

### DIFF
--- a/src/Parser.test.ts
+++ b/src/Parser.test.ts
@@ -491,6 +491,80 @@ describe("Parser", () => {
     const a = file.statements[0] as AssignmentNode;
     expect(simplifyAst(a.value!)).toMatchSnapshot();
   });
+  it("parses '^' as right-associative", () => {
+    // real OpenSCAD: 2^2^3 === 2^(2^3) === 256, not (2^2)^3 === 64
+    const file = doParse(`
+      x = 2^2^3;
+    `);
+    const a = file.statements[0] as AssignmentNode;
+    expect(a.value).toBeInstanceOf(BinaryOpExpr);
+    expect(a.value).toHaveProperty("operation", TokenType.Caret);
+    expect(a.value).toHaveProperty("left.value", 2);
+    expect(a.value).toHaveProperty("right.operation", TokenType.Caret);
+    expect(a.value).toHaveProperty("right.left.value", 2);
+    expect(a.value).toHaveProperty("right.right.value", 3);
+  });
+  it("gives unary minus lower precedence than '^', matching real OpenSCAD (-2^2 === -4, not 4)", () => {
+    const file = doParse(`
+      x = -2^2;
+    `);
+    const a = file.statements[0] as AssignmentNode;
+    expect(a.value).toBeInstanceOf(UnaryOpExpr);
+    expect(a.value).toHaveProperty("operation", TokenType.Minus);
+    expect(a.value).toHaveProperty("right.operation", TokenType.Caret);
+    expect(a.value).toHaveProperty("right.left.value", 2);
+    expect(a.value).toHaveProperty("right.right.value", 2);
+  });
+  it("allows a unary minus on the exponent (2^-2 === 0.25)", () => {
+    const file = doParse(`
+      x = 2^-2;
+    `);
+    const a = file.statements[0] as AssignmentNode;
+    expect(a.value).toBeInstanceOf(BinaryOpExpr);
+    expect(a.value).toHaveProperty("operation", TokenType.Caret);
+    expect(a.value).toHaveProperty("left.value", 2);
+    expect(a.value).toHaveProperty("right.operation", TokenType.Minus);
+    expect(a.value).toHaveProperty("right.right.value", 2);
+  });
+  it("wraps a whole right-associative '^' chain in a leading unary minus (-2^2^2 === -16)", () => {
+    const file = doParse(`
+      x = -2^2^2;
+    `);
+    const a = file.statements[0] as AssignmentNode;
+    expect(a.value).toBeInstanceOf(UnaryOpExpr);
+    expect(a.value).toHaveProperty("operation", TokenType.Minus);
+    expect(a.value).toHaveProperty("right.operation", TokenType.Caret);
+    expect(a.value).toHaveProperty("right.left.value", 2);
+    expect(a.value).toHaveProperty("right.right.operation", TokenType.Caret);
+    expect(a.value).toHaveProperty("right.right.left.value", 2);
+    expect(a.value).toHaveProperty("right.right.right.value", 2);
+  });
+  it("keeps '-2^2' as a single unit when used as a multiplication operand (2*-2^2 === -8)", () => {
+    const file = doParse(`
+      x = 2*-2^2;
+    `);
+    const a = file.statements[0] as AssignmentNode;
+    expect(a.value).toBeInstanceOf(BinaryOpExpr);
+    expect(a.value).toHaveProperty("operation", TokenType.Star);
+    expect(a.value).toHaveProperty("left.value", 2);
+    expect(a.value).toHaveProperty("right.operation", TokenType.Minus);
+    expect(a.value).toHaveProperty("right.right.operation", TokenType.Caret);
+    expect(a.value).toHaveProperty("right.right.left.value", 2);
+    expect(a.value).toHaveProperty("right.right.right.value", 2);
+  });
+  it("does not let a leading unary minus reach past a parenthesized base (-(-2)^2 === -4)", () => {
+    const file = doParse(`
+      x = -(-2)^2;
+    `);
+    const a = file.statements[0] as AssignmentNode;
+    expect(a.value).toBeInstanceOf(UnaryOpExpr);
+    expect(a.value).toHaveProperty("operation", TokenType.Minus);
+    const powExpr = (a.value as UnaryOpExpr).right as BinaryOpExpr;
+    expect(powExpr).toBeInstanceOf(BinaryOpExpr);
+    expect(powExpr.operation).toEqual(TokenType.Caret);
+    expect(powExpr.left).toBeInstanceOf(GroupingExpr);
+    expect(powExpr).toHaveProperty("right.value", 2);
+  });
   it("parses the '-' unary operator", () => {
     const file = doParse(`
       x = -10;

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -747,25 +747,10 @@ export default class Parser {
     return expr;
   }
   protected multiplication(): Expression {
-    let expr = this.exponentiation();
+    let expr = this.unary();
     while (
       this.matchToken(TokenType.Star, TokenType.Slash, TokenType.Percent)
     ) {
-      const operator = this.previous();
-      const right = this.exponentiation();
-      expr = new BinaryOpExpr(expr, operator.type, right, {
-        operator,
-      });
-    }
-    return expr;
-  }
-
-  /**
-   * Parses b ^ e.
-   */
-  protected exponentiation(): Expression {
-    let expr = this.unary();
-    while (this.matchToken(TokenType.Caret)) {
       const operator = this.previous();
       const right = this.unary();
       expr = new BinaryOpExpr(expr, operator.type, right, {
@@ -776,7 +761,27 @@ export default class Parser {
   }
 
   /**
-   * Parses +expr, -expr and !expr.
+   * Parses b ^ e. Right-associative (2^2^3 === 2^(2^3)) and binds tighter
+   * than unary operators, so its base is parsed via memberLookupOrArrayLookup
+   * rather than unary - a leading unary operator instead wraps the whole
+   * expression from the `unary()` method below, matching real OpenSCAD's
+   * `-2^2 === -4` rather than `4`. The exponent itself is parsed via
+   * `unary()` so it may carry its own sign, e.g. `2^-2`.
+   */
+  protected exponentiation(): Expression {
+    const expr = this.memberLookupOrArrayLookup();
+    if (this.matchToken(TokenType.Caret)) {
+      const operator = this.previous();
+      const right = this.unary();
+      return new BinaryOpExpr(expr, operator.type, right, {
+        operator,
+      });
+    }
+    return expr;
+  }
+
+  /**
+   * Parses +expr, -expr and !expr. Binds looser than '^' (see exponentiation()).
    */
   protected unary(): Expression {
     if (this.matchToken(TokenType.Plus, TokenType.Minus, TokenType.Bang)) {
@@ -786,7 +791,7 @@ export default class Parser {
         operator,
       });
     }
-    return this.memberLookupOrArrayLookup();
+    return this.exponentiation();
   }
   protected memberLookupOrArrayLookup() {
     let expr = this.primary();


### PR DESCRIPTION
## Summary

`echo(-2^2);` parses (and evaluates, once fed to consumers of this AST) as `(-2)^2 == 4`. Real OpenSCAD groups it as `-(2^2) == -4` — unary minus binds looser than `^` here, same convention as Python's `-2**2`.

While tracing this I found the existing grammar also made `^` left-associative: `2^2^3` parsed as `(2^2)^3 == 64` instead of real OpenSCAD's `2^(2^3) == 256`.

Verified against a local OpenSCAD `2026.09.05` build (`openscad -o x.echo x.scad`) for a battery of related expressions — all now match:

| expr | real OpenSCAD |
|---|---|
| `-2^2` | `-4` |
| `2^-2` | `0.25` |
| `-2^-2` | `-0.25` |
| `2^2^3` | `256` |
| `-2^2^2` | `-16` |
| `2*-2^2` | `-8` |
| `-(-2)^2` | `-4` |
| `--2^2` | `4` |
| `2^-1*4` | `2` |

I also spot-checked nearby operators (comparison, `%`, and — on the already-merged bitwise-operators branch — `<<`/`|`/`&`) against real OpenSCAD and didn't find any other precedence mismatches.

## Root cause

`exponentiation()` called `unary()` for its base, and `unary()` bottomed out directly in the postfix/primary parser instead of deferring to `exponentiation()`. That let a leading unary operator bind to the base alone rather than to the whole `^` expression. `exponentiation()` also used a `while` loop, making it left-associative.

## Fix

- `multiplication()` now calls `unary()` (was `exponentiation()`).
- `unary()`, when no unary operator is present, defers to `exponentiation()` (was `memberLookupOrArrayLookup()`).
- `exponentiation()`'s base is now `memberLookupOrArrayLookup()` directly (was `unary()`), and it recurses into `unary()` on the right-hand side of `^` instead of looping — right-associative, while still allowing a signed exponent (`2^-2`).

## Test plan
- [x] TDD: added 6 failing tests first reproducing the precedence/associativity bugs against real-OpenSCAD-verified expected groupings; confirmed they failed against the old code
- [x] Applied the fix; all 6 pass, plus the existing `10 * 2^8` snapshot test is unaffected
- [x] Full suite passes: 222 passed, 2 skipped, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)